### PR TITLE
Add path for apple-touch-icon-120x120-precomposed.png

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /spec/reports/
 /tmp/
 .consolerc
+vendor

--- a/lib/rack/favicon_all.rb
+++ b/lib/rack/favicon_all.rb
@@ -25,6 +25,7 @@ module Rack
       { path: /\A\/apple-touch-icon-152x152\.png/, size: [152, 152] },
       { path: /\A\/apple-touch-icon\.png/, size: [57, 57] },
       { path: /\A\/apple-touch-icon-precomposed\.png/, size: [57, 57] },
+      { path: /\A\/apple-touch-icon-120x120-precomposed\.png/, size: [120, 120] }
     ]
     def initialize(app, options = {})
       @app = app


### PR DESCRIPTION
Fix for `apple-touch-icon-120x120-precomposed.png`
